### PR TITLE
Revert emmy version in the emmy plugin

### DIFF
--- a/plugins/demo_emmy/bb.edn
+++ b/plugins/demo_emmy/bb.edn
@@ -36,13 +36,7 @@
                  (deref (promise)))}
 
   release {:doc "Release build (advanced compiled JS)"
-           :task (let [path-to-fix "resources/public/js/scittle.emmy-viewers.js"]
-                   (build/build {})
-                   (-> path-to-fix
-                       slurp
-                       (str/replace (re-pattern "-ͯ")
-                                    "")
-                       (->> (spit path-to-fix))))}
+           :task (build/build {})}
 
   serve {:doc "Start http server for serving static files (blocking)"
          :task (do (run 'http-server)

--- a/plugins/demo_emmy/bb.edn
+++ b/plugins/demo_emmy/bb.edn
@@ -7,7 +7,8 @@
         }
  :tasks
  {:requires ([scittle.build :as build]
-             [babashka.fs :as fs])
+             [babashka.fs :as fs]
+             [clojure.string :as str])
 
   clean {:doc "Start from clean slate."
          :task (do (run! fs/delete (fs/list-dir (fs/file "resources" "public" "js") "**.*"))
@@ -35,7 +36,13 @@
                  (deref (promise)))}
 
   release {:doc "Release build (advanced compiled JS)"
-           :task (build/build {})}
+           :task (let [path-to-fix "resources/public/js/scittle.emmy-viewers.js"]
+                   (build/build {})
+                   (-> path-to-fix
+                       slurp
+                       (str/replace (re-pattern "-ͯ")
+                                    "")
+                       (->> (spit path-to-fix))))}
 
   serve {:doc "Start http server for serving static files (blocking)"
          :task (do (run 'http-server)

--- a/plugins/demo_emmy/resources/public/example.cljs
+++ b/plugins/demo_emmy/resources/public/example.cljs
@@ -37,8 +37,7 @@
 
 (require
  '[emmy.env :as e]
- '[emmy.mafs :as mafs]
- )
+ '[emmy.mafs :as mafs])
 
 (def some-graph
   (mafs/mafs

--- a/plugins/demo_emmy/resources/public/index.html
+++ b/plugins/demo_emmy/resources/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="https://unpkg.com/computer-modern@0.1.2/cmu-serif.css">
     <link rel="stylesheet" href="https://unpkg.com/mafs@0.18.8/core.css">
     <link rel="stylesheet" href="https://unpkg.com/mafs@0.18.8/font.css">

--- a/plugins/emmy/deps.edn
+++ b/plugins/emmy/deps.edn
@@ -1,7 +1,6 @@
 {:deps
- {io.github.mentat-collective/emmy {:git/sha "53fd9909b835e7eeb21f798ba61fd7e6b5251cfc"
+ {io.github.mentat-collective/emmy {:mvn/version "0.31.0"
                                     :exclusions [org.babashka/sci
                                                  org.mentat/clerk-utils]}
   org.mentat/clerk-utils {:mvn/version "0.6.0"
-                          :exclusions [thheller/shadow-cljs]}
-  }}
+                          :exclusions [thheller/shadow-cljs]}}}

--- a/plugins/emmy_viewers/deps.edn
+++ b/plugins/emmy_viewers/deps.edn
@@ -1,13 +1,11 @@
 {:deps
  {io.github.mentat-collective/emmy-viewers
-  {:git/sha "0a33ca99dc6d189b07bea50c484f2a3eaf2747b0"
+  {:mvn/version "0.3.2"
    :exclusions [org.mentat/emmy
                 org.mentat/clerk-utils]}
 
-  io.github.mentat-collective/emmy {:git/sha    "53fd9909b835e7eeb21f798ba61fd7e6b5251cfc"
+  io.github.mentat-collective/emmy {:mvn/version "0.31.0"
                                     :exclusions [org.babashka/sci
                                                  org.mentat/clerk-utils]}
   org.mentat/clerk-utils {:mvn/version "0.6.0"
-                          :exclusions  [thheller/shadow-cljs]}
-
-  }}
+                          :exclusions  [thheller/shadow-cljs]}}}


### PR DESCRIPTION
* changed the version in the `deps.edn` for the plugins:
  * `emmy` is `0.31.0` -- previous version as advised by Sam
  * `emmy-viewers` is `0.3.2` -- most recent version at Clojars
 
* updated example code following the Slack discussion:
https://clojurians.slack.com/archives/C034FQN490E/p1729310177162729?thread_ts=1717758772.607549&cid=C034FQN490E

* removed strange characters on the plugin build